### PR TITLE
hotfix: incorrect route in Link component

### DIFF
--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -39,7 +39,7 @@ export const Route = createRootRoute({
         <div className="p-2 flex gap-2">
           <Link to="/">승차권 확인</Link>
           <br />
-          <Link to="/booking">예매하기</Link>
+          <Link to="/booking/tickets">예매하기</Link>
           <br />
           <Link to="/account">마이페이지</Link>
         </div>


### PR DESCRIPTION
## Summary

잘못된 route string을 수정합니다.

## Description

- Link component에서, 정의되어 있지 않은 route로 네비게이팅이 지정되어 있어 타입 오류가 발생하였습니다.