### PR TITLE
Ci/make build and deploly sequential

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,10 +7,6 @@ on:
     types:
       - completed
 
-  push:
-    branches:
-      - main
-
   pull_request:
     branches:
       - main

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,30 @@ on:
       - main
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.11.0
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Build the project
+        run: yarn build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ./dist
+
   deploy:
     runs-on: ubuntu-latest
 
@@ -23,10 +47,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: ./dist
+          path: ./dist'
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: dist
+          publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build
-          path: ./dist
+          path: dist
 
   deploy:
     runs-on: ubuntu-latest
@@ -47,10 +47,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build
-          path: ./dist'
+          path: dist
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          publish_dir: dist


### PR DESCRIPTION
## Summary

deploy 전에 build를 할 수 있도록 workflow를 수정하였습니다.

## Description 

- deploy 과정에서 사전에 build를 할 수 있도록 설정하였는데, 그 이유는 다음과 같습니다.
  - build를 실행이 끝난 뒤에 deploy가 되도록 만들려면, 같은 jobs 안에 두어야 합니다.(sequentail)
  - 다른 workflow 사이에는 artifact를 공유하지 않습니다. 따라서, deploy workflow에서는 build file에서 만든 artifact에 접근이 불가능합니다.
- 기존의 build.yml은 pull request시에만 실행될 수 있도록 하여 main에 merge될 때 build가 두번 되는 현상을 방지하였습니다.