### PR TITLE
Ci/sequential build and deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build the project
         run: yarn build
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,12 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  workflow_run:
-    workflows:
-      - Build Project
-    types:
-      - completed
-
   push:
     branches:
       - main
@@ -37,6 +31,7 @@ jobs:
           path: dist
 
   deploy:
+    needs: build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,27 +25,24 @@ jobs:
         run: yarn build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
-          name: build
           path: dist
 
   deploy:
-    needs: build
     runs-on: ubuntu-latest
 
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    needs: build
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build
-          path: dist
-
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: dist
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

deploy job에서 발생하는 버그를 수정했습니다.


## Description

- jobs는 비동기적으로 동작하므로, deploy 전에 build를 하기 위해서 `needs`를 통해서 build job을 기다리게 만들었습니다.
- deploy-pages를 사용하여 더 간단하게 workflow를 구성하였습니다.

https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow

해당 actions를 사용하였습니다.
https://github.com/actions/deploy-pages
https://github.com/actions/upload-pages-artifact
