### PR TITLE
refactor: add `import type` for readability

### DIFF
--- a/src/common/components/BottomBar/index.tsx
+++ b/src/common/components/BottomBar/index.tsx
@@ -1,5 +1,5 @@
 import { bottomBar, buttonContainer } from './index.styles';
-import { BottomBarPropsType } from './types';
+import type { BottomBarPropsType } from './types';
 
 function BottomBar({ leftSlot, centerSlot, rightSlot }: BottomBarPropsType) {
   return (

--- a/src/common/components/BottomBar/types.ts
+++ b/src/common/components/BottomBar/types.ts
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react';
+
 export type BottomBarPropsType = {
-  leftSlot?: React.ReactNode;
-  centerSlot?: React.ReactNode;
-  rightSlot?: React.ReactNode;
+  leftSlot?: ReactNode;
+  centerSlot?: ReactNode;
+  rightSlot?: ReactNode;
 };

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -1,5 +1,5 @@
 import { container } from './index.styles';
-import { ButtonPropsType } from './index.types';
+import type { ButtonPropsType } from './index.types';
 
 export default function Button({
   children,

--- a/src/common/components/Button/index.types.ts
+++ b/src/common/components/Button/index.types.ts
@@ -1,4 +1,5 @@
-export interface ButtonPropsType
-  extends React.ComponentPropsWithoutRef<'button'> {
-  children: React.ReactNode;
+import type { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+export interface ButtonPropsType extends ComponentPropsWithoutRef<'button'> {
+  children: ReactNode;
 }

--- a/src/common/components/Card/index.tsx
+++ b/src/common/components/Card/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { CardPropsType } from './types';
+import type { CardPropsType } from './types';
 import { container } from './index.styles';
 
 export default function Card({ header, body, footer }: CardPropsType) {

--- a/src/common/components/Flex/index.styles.ts
+++ b/src/common/components/Flex/index.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { FlexPropsType } from './index.types';
+import type { FlexPropsType } from './index.types';
 
 export const buildFlex = ({
   justify,

--- a/src/common/components/Flex/index.tsx
+++ b/src/common/components/Flex/index.tsx
@@ -1,4 +1,4 @@
-import { FlexPropsType } from './index.types';
+import type { FlexPropsType } from './index.types';
 import { buildFlex } from './index.styles';
 
 export default function Flex({

--- a/src/common/components/Flex/index.types.ts
+++ b/src/common/components/Flex/index.types.ts
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
 
 export interface FlexPropsType extends ComponentPropsWithoutRef<'div'> {
   children?: ReactNode;

--- a/src/common/components/IconButton/index.tsx
+++ b/src/common/components/IconButton/index.tsx
@@ -1,4 +1,5 @@
-import { css } from "@emotion/react";
+import { css } from '@emotion/react';
+import type { ImgHTMLAttributes } from 'react';
 
 const container = css`
   width: 44px;
@@ -13,10 +14,8 @@ const container = css`
   }
 `;
 
-function IconButton({...rest}: React.ImgHTMLAttributes<HTMLImageElement>) {
-  return (
-    <img css={container} {...rest}/>
-  )
+function IconButton({ ...rest }: ImgHTMLAttributes<HTMLImageElement>) {
+  return <img css={container} {...rest} />;
 }
 
 export default IconButton;

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -1,5 +1,5 @@
-import React, { ChangeEvent } from 'react';
-import { InputPropsType } from './index.types';
+import type { ChangeEvent } from 'react';
+import type { InputPropsType } from './index.types';
 import { useInput } from './index.styles';
 import { useTheme } from '@emotion/react';
 

--- a/src/common/components/Input/index.types.ts
+++ b/src/common/components/Input/index.types.ts
@@ -1,5 +1,6 @@
-export interface InputPropsType
-  extends React.ComponentPropsWithoutRef<'input'> {
+import type { ComponentPropsWithoutRef } from 'react';
+
+export interface InputPropsType extends ComponentPropsWithoutRef<'input'> {
   value: string;
   onValueChange: (value: string) => void;
   error?: string;

--- a/src/common/components/LanguageSwitchButton/index.tsx
+++ b/src/common/components/LanguageSwitchButton/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LanguagePropsType } from './index.types';
+import type { LanguagePropsType } from './index.types';
 import Button from '../Button';
 import { buildLanguageSwitchButton } from './index.styles';
 import { useTheme } from '@emotion/react';

--- a/src/common/components/TopBar/index.tsx
+++ b/src/common/components/TopBar/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TopBarPropsType } from './types';
+import type { TopBarPropsType } from './types';
 import { container } from './index.styles';
 
 export default function TopBar({

--- a/src/common/components/TopBar/types.ts
+++ b/src/common/components/TopBar/types.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
 export interface TopBarPropsType {
   exitButton?: ReactNode;

--- a/src/common/components/Typography/index.styles.ts
+++ b/src/common/components/Typography/index.styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { ThemeType } from '../../../theme';
+import type { ThemeType } from '../../../theme';
 import { TypographyVariant } from './index.types';
 
 export const buildTypography = (

--- a/src/common/components/Typography/index.tsx
+++ b/src/common/components/Typography/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { buildTypography } from './index.styles';
 import { useTheme } from '@emotion/react';
-import { TypographyPropsType } from './index.types';
+import type { TypographyPropsType } from './index.types';
 
 function Typography({
   variant,

--- a/src/common/components/Typography/index.types.ts
+++ b/src/common/components/Typography/index.types.ts
@@ -1,3 +1,5 @@
+import type { ElementType, ReactNode } from 'react';
+
 export type TypographyVariant =
   | 'title1'
   | 'title2'
@@ -11,6 +13,6 @@ export type TypographyVariant =
 
 export interface TypographyPropsType {
   variant: TypographyVariant;
-  children: React.ReactNode;
-  as?: React.ElementType;
+  children: ReactNode;
+  as?: ElementType;
 }

--- a/src/stories/BottomBar.stories.tsx
+++ b/src/stories/BottomBar.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import BottomBar from '../common/components/BottomBar';
 import PersonIcon from '../assets/PersonIcon.svg?react';
 import QRIcon from '../assets/QRIcon.svg?react';

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Button from '../common/components/Button';
 
 const meta = {

--- a/src/stories/Card.stories.tsx
+++ b/src/stories/Card.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Card from '../common/components/Card';
 
 const meta = {

--- a/src/stories/Input.stories.tsx
+++ b/src/stories/Input.stories.tsx
@@ -1,5 +1,5 @@
 import Input from '../common/components/Input';
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 const meta = {
   title: 'common/Input',

--- a/src/stories/LanguageSwitchButton.stories.tsx
+++ b/src/stories/LanguageSwitchButton.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import LanguageSwitchButton from '../common/components/LanguageSwitchButton';
 
 const meta = {

--- a/src/stories/TopBar.stories.tsx
+++ b/src/stories/TopBar.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import TopBar from '../common/components/TopBar';
 import LogoIcon from '../assets/LogoIcon.svg?react';
 import { css } from '@emotion/react';

--- a/src/stories/Typography.stories.tsx
+++ b/src/stories/Typography.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import Typography from '../common/components/Typography';
 
 const meta = {


### PR DESCRIPTION
## Summary

type을 보다 명확히 명시하기 위해 import type {} 문법을 사용하여 type을 표현하도록 리펙토링했습니다.

## Description

Same as above