### PR TITLE
refactor: enable custom styling via css prop

### DIFF
--- a/src/common/components/BottomBar/index.styles.ts
+++ b/src/common/components/BottomBar/index.styles.ts
@@ -17,15 +17,7 @@ export const bottomBar = css([
   },
 ]);
 
-export const buttonContainer = css([
-  buildFlex({
-    justify: 'center',
-    align: 'center',
-    direction: 'column',
-    wrap: 'nowrap',
-    gap: '0',
-  }),
-  {
-    flex: 'auto',
-  },
-]);
+export const buttonContainer = css({
+  flex: 'auto',
+  flexDirection: 'column',
+});

--- a/src/common/components/BottomBar/index.tsx
+++ b/src/common/components/BottomBar/index.tsx
@@ -1,12 +1,13 @@
+import Flex from '../Flex';
 import { bottomBar, buttonContainer } from './index.styles';
 import { BottomBarPropsType } from './types';
 
 function BottomBar({ leftSlot, centerSlot, rightSlot }: BottomBarPropsType) {
   return (
     <div css={bottomBar}>
-      <div css={buttonContainer}>{leftSlot}</div>
-      <div css={buttonContainer}>{centerSlot}</div>
-      <div css={buttonContainer}>{rightSlot}</div>
+      <Flex css={buttonContainer}>{leftSlot}</Flex>
+      <Flex css={buttonContainer}>{centerSlot}</Flex>
+      <Flex css={buttonContainer}>{rightSlot}</Flex>
     </div>
   );
 }

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -5,11 +5,12 @@ export default function Button({
   children,
   type = 'button',
   css,
+  as: Component = 'button',
   ...rest
 }: ButtonPropsType) {
   return (
-    <button css={[container, ...(css ? [css] : [])]} type={type} {...rest}>
+    <Component css={[container, ...(css ? [css] : [])]} type={type} {...rest}>
       {children}
-    </button>
+    </Component>
   );
 }

--- a/src/common/components/Button/index.tsx
+++ b/src/common/components/Button/index.tsx
@@ -4,10 +4,11 @@ import { ButtonPropsType } from './index.types';
 export default function Button({
   children,
   type = 'button',
+  css,
   ...rest
 }: ButtonPropsType) {
   return (
-    <button css={container} type={type} {...rest}>
+    <button css={[container, ...(css ? [css] : [])]} type={type} {...rest}>
       {children}
     </button>
   );

--- a/src/common/components/Button/index.types.ts
+++ b/src/common/components/Button/index.types.ts
@@ -1,4 +1,7 @@
+import type { SerializedStyles } from '@emotion/react';
+
 export interface ButtonPropsType
   extends React.ComponentPropsWithoutRef<'button'> {
   children: React.ReactNode;
+  css?: SerializedStyles;
 }

--- a/src/common/components/Button/index.types.ts
+++ b/src/common/components/Button/index.types.ts
@@ -1,7 +1,9 @@
 import type { SerializedStyles } from '@emotion/react';
+import type { ElementType } from 'react';
 
 export interface ButtonPropsType
   extends React.ComponentPropsWithoutRef<'button'> {
   children: React.ReactNode;
   css?: SerializedStyles;
+  as?: ElementType;
 }

--- a/src/common/components/Flex/index.tsx
+++ b/src/common/components/Flex/index.tsx
@@ -8,22 +8,27 @@ export default function Flex({
   direction = 'row',
   gap = '0',
   wrap = 'nowrap',
-  width = '100%',
+  width = 'auto',
+  as: Component = 'div',
+  css,
   ...rest
 }: FlexPropsType) {
   return (
-    <div
-      css={buildFlex({
-        align,
-        justify,
-        direction,
-        gap,
-        wrap,
-        width,
-      })}
+    <Component
+      css={[
+        buildFlex({
+          align,
+          justify,
+          direction,
+          gap,
+          wrap,
+          width,
+        }),
+        ...(css ? [css] : []),
+      ]}
       {...rest}
     >
       {children}
-    </div>
+    </Component>
   );
 }

--- a/src/common/components/Flex/index.types.ts
+++ b/src/common/components/Flex/index.types.ts
@@ -1,4 +1,10 @@
-import { ComponentPropsWithoutRef, CSSProperties, ReactNode } from 'react';
+import { SerializedStyles } from '@emotion/react';
+import type {
+  ComponentPropsWithoutRef,
+  CSSProperties,
+  ElementType,
+  ReactNode,
+} from 'react';
 
 export interface FlexPropsType extends ComponentPropsWithoutRef<'div'> {
   children?: ReactNode;
@@ -8,4 +14,6 @@ export interface FlexPropsType extends ComponentPropsWithoutRef<'div'> {
   gap?: CSSProperties['gap'];
   wrap?: CSSProperties['flexWrap'];
   width?: CSSProperties['width'];
+  css?: SerializedStyles;
+  as?: ElementType;
 }

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -9,6 +9,7 @@ export default function Input({
   type = 'text',
   error,
   css,
+  as: Component = 'input',
   ...rest
 }: InputPropsType) {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -17,7 +18,7 @@ export default function Input({
   const theme = useTheme();
 
   return (
-    <input
+    <Component
       css={[useInput(theme), ...(css ? [css] : [])]}
       type={type}
       value={value}

--- a/src/common/components/Input/index.tsx
+++ b/src/common/components/Input/index.tsx
@@ -8,6 +8,7 @@ export default function Input({
   onValueChange,
   type = 'text',
   error,
+  css,
   ...rest
 }: InputPropsType) {
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -17,7 +18,7 @@ export default function Input({
 
   return (
     <input
-      css={useInput(theme)}
+      css={[useInput(theme), ...(css ? [css] : [])]}
       type={type}
       value={value}
       onChange={handleChange}

--- a/src/common/components/Input/index.types.ts
+++ b/src/common/components/Input/index.types.ts
@@ -1,4 +1,5 @@
-import { SerializedStyles } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+import type { ElementType } from 'react';
 
 export interface InputPropsType
   extends React.ComponentPropsWithoutRef<'input'> {
@@ -6,4 +7,5 @@ export interface InputPropsType
   onValueChange: (value: string) => void;
   error?: string;
   css?: SerializedStyles;
+  as?: ElementType;
 }

--- a/src/common/components/Input/index.types.ts
+++ b/src/common/components/Input/index.types.ts
@@ -1,6 +1,9 @@
+import { SerializedStyles } from '@emotion/react';
+
 export interface InputPropsType
   extends React.ComponentPropsWithoutRef<'input'> {
   value: string;
   onValueChange: (value: string) => void;
   error?: string;
+  css?: SerializedStyles;
 }


### PR DESCRIPTION
## Summary

Global Components에서도 css prop을 통해서 custom styling 및 custom tagging이 가능하도록 수정하였습니다.

## Description

emotion의 css만 쓴다면, default props를 효율적으로 사용하지 못한다는 @YangJJune의 피드백이 있었습니다. 따라서 css props를 사용하여 global component의 커스텀 스타일링이 가능하도록 수정했습니다.