### PR TITLE
feat/reusable sticky layouts

### DIFF
--- a/src/common/components/ActionBar/index.styles.ts
+++ b/src/common/components/ActionBar/index.styles.ts
@@ -1,0 +1,9 @@
+import { css, Theme } from '@emotion/react';
+
+export const buildActionBar = (theme: Theme) =>
+  css({
+    backgroundColor: theme.colors.gray.white,
+    padding: '20px 20px 34px 20px',
+    boxShadow: '0px 0px 20px rgba(0, 0, 0, 0.15)',
+    borderRadius: '20px 20px 0 0',
+  });

--- a/src/common/components/ActionBar/index.tsx
+++ b/src/common/components/ActionBar/index.tsx
@@ -1,32 +1,24 @@
-import React from 'react';
 import type { ActionBarPropsType } from './index.types';
 import Flex from '../Flex';
-import { css, useTheme } from '@emotion/react';
-import Typography from '../Typography';
+
+import { buildActionBar } from './index.styles';
+import { useTheme } from '@emotion/react';
 
 export default function ActionBar({
   bodySlot,
   actionSlot,
+  cx,
 }: ActionBarPropsType) {
   const theme = useTheme();
   return (
     <Flex
       as="section"
-      justify="center"
-      align="center"
-      css={css({
-        margin: '20px 20px 34px 20px',
-      })}
+      direction="column"
+      cx={[buildActionBar(theme), cx]}
+      gap="28px"
+      width="100%"
+      boxSizing="border-box"
     >
-      <Typography
-        as="p"
-        variant="body4"
-        cx={css({
-          color: theme.colors.gray[4],
-        })}
-      >
-        일반 1, 초등생 1
-      </Typography>
       {bodySlot}
       {actionSlot}
     </Flex>

--- a/src/common/components/ActionBar/index.types.ts
+++ b/src/common/components/ActionBar/index.types.ts
@@ -1,6 +1,8 @@
+import type { Interpolation, Theme } from '@emotion/react';
 import type { ReactNode } from 'react';
 
 export interface ActionBarPropsType {
   bodySlot?: ReactNode;
   actionSlot: ReactNode;
+  cx?: Interpolation<Theme>;
 }

--- a/src/common/components/Flex/index.styles.ts
+++ b/src/common/components/Flex/index.styles.ts
@@ -8,6 +8,7 @@ export const buildFlex = ({
   wrap,
   gap,
   width,
+  boxSizing,
 }: FlexPropsType) =>
   css({
     display: 'flex',
@@ -17,4 +18,5 @@ export const buildFlex = ({
     flexWrap: wrap,
     gap,
     width,
+    boxSizing,
   });

--- a/src/common/components/Flex/index.tsx
+++ b/src/common/components/Flex/index.tsx
@@ -9,6 +9,7 @@ export default function Flex({
   gap = '0',
   wrap = 'nowrap',
   width = 'auto',
+  boxSizing = 'content-box',
   as: Component = 'div',
   cx,
   ...rest
@@ -23,6 +24,7 @@ export default function Flex({
           gap,
           wrap,
           width,
+          boxSizing,
         }),
         cx,
       ]}

--- a/src/common/components/Flex/index.types.ts
+++ b/src/common/components/Flex/index.types.ts
@@ -14,6 +14,7 @@ export interface FlexPropsType extends ComponentPropsWithoutRef<'div'> {
   gap?: CSSProperties['gap'];
   wrap?: CSSProperties['flexWrap'];
   width?: CSSProperties['width'];
+  boxSizing?: CSSProperties['boxSizing'];
   cx?: Interpolation<Theme>;
   as?: ElementType;
 }

--- a/src/common/components/StickyFooter/index.styles.ts
+++ b/src/common/components/StickyFooter/index.styles.ts
@@ -1,0 +1,10 @@
+import { css, type Theme } from '@emotion/react';
+
+export const buildStickyFooter = (theme: Theme) =>
+  css({
+    position: 'sticky',
+    bottom: 0,
+    width: '100%',
+    backgroundColor: theme.colors.gray.white,
+    zIndex: theme.zIndex.dropdown,
+  });

--- a/src/common/components/StickyFooter/index.tsx
+++ b/src/common/components/StickyFooter/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { StickyFooterPropsType } from './index.types';
+import { useTheme } from '@emotion/react';
+import { buildStickyFooter } from './index.styles';
+
+export default function StickyFooter({
+  children,
+  as: Component = 'footer',
+  cx,
+}: StickyFooterPropsType) {
+  const theme = useTheme();
+  return <Component css={[buildStickyFooter(theme), cx]}>{children}</Component>;
+}

--- a/src/common/components/StickyFooter/index.types.ts
+++ b/src/common/components/StickyFooter/index.types.ts
@@ -1,0 +1,8 @@
+import type { Interpolation, Theme } from '@emotion/react';
+import type { ElementType, ReactNode } from 'react';
+
+export interface StickyFooterPropsType {
+  as?: ElementType;
+  children: ReactNode;
+  cx?: Interpolation<Theme>;
+}

--- a/src/common/components/StickyHeader/index.styles.ts
+++ b/src/common/components/StickyHeader/index.styles.ts
@@ -1,0 +1,10 @@
+import { css, Theme } from '@emotion/react';
+
+export const buildStickyHeader = (theme: Theme) =>
+  css({
+    backgroundColor: theme.colors.gray.white,
+    top: 0,
+    position: 'sticky',
+    width: '100%',
+    zIndex: theme.zIndex.dropdown,
+  });

--- a/src/common/components/StickyHeader/index.tsx
+++ b/src/common/components/StickyHeader/index.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import { StikcyHeaderPropsType } from './index.types';
+import { buildStickyHeader } from './index.styles';
+import { useTheme } from '@emotion/react';
+
+export default function StikcyHeader({ children }: StikcyHeaderPropsType) {
+  const theme = useTheme();
+  return <header css={buildStickyHeader(theme)}>{children}</header>;
+}

--- a/src/common/components/StickyHeader/index.tsx
+++ b/src/common/components/StickyHeader/index.tsx
@@ -3,7 +3,10 @@ import { StikcyHeaderPropsType } from './index.types';
 import { buildStickyHeader } from './index.styles';
 import { useTheme } from '@emotion/react';
 
-export default function StikcyHeader({ children }: StikcyHeaderPropsType) {
+export default function StikcyHeader({
+  children,
+  as: Component = 'header',
+}: StikcyHeaderPropsType) {
   const theme = useTheme();
-  return <header css={buildStickyHeader(theme)}>{children}</header>;
+  return <Component css={buildStickyHeader(theme)}>{children}</Component>;
 }

--- a/src/common/components/StickyHeader/index.tsx
+++ b/src/common/components/StickyHeader/index.tsx
@@ -6,7 +6,8 @@ import { useTheme } from '@emotion/react';
 export default function StikcyHeader({
   children,
   as: Component = 'header',
+  cx,
 }: StikcyHeaderPropsType) {
   const theme = useTheme();
-  return <Component css={buildStickyHeader(theme)}>{children}</Component>;
+  return <Component css={[buildStickyHeader(theme), cx]}>{children}</Component>;
 }

--- a/src/common/components/StickyHeader/index.types.ts
+++ b/src/common/components/StickyHeader/index.types.ts
@@ -1,0 +1,5 @@
+import type { ReactNode } from 'react';
+
+export interface StikcyHeaderPropsType {
+  children: ReactNode;
+}

--- a/src/common/components/StickyHeader/index.types.ts
+++ b/src/common/components/StickyHeader/index.types.ts
@@ -1,5 +1,6 @@
-import type { ReactNode } from 'react';
+import type { ElementType, ReactNode } from 'react';
 
 export interface StikcyHeaderPropsType {
+  as?: ElementType;
   children: ReactNode;
 }

--- a/src/common/components/StickyHeader/index.types.ts
+++ b/src/common/components/StickyHeader/index.types.ts
@@ -4,5 +4,5 @@ import type { ElementType, ReactNode } from 'react';
 export interface StikcyHeaderPropsType {
   as?: ElementType;
   children: ReactNode;
-  cx: Interpolation<Theme>;
+  cx?: Interpolation<Theme>;
 }

--- a/src/common/components/StickyHeader/index.types.ts
+++ b/src/common/components/StickyHeader/index.types.ts
@@ -1,6 +1,8 @@
+import type { Interpolation, Theme } from '@emotion/react';
 import type { ElementType, ReactNode } from 'react';
 
 export interface StikcyHeaderPropsType {
   as?: ElementType;
   children: ReactNode;
+  cx: Interpolation<Theme>;
 }

--- a/src/common/components/TopBar/index.styles.ts
+++ b/src/common/components/TopBar/index.styles.ts
@@ -1,15 +1,7 @@
 import { css } from '@emotion/react';
-import { buildFlex } from '../Flex/index.styles';
 
 export const container = css([
-  buildFlex({
-    justify: 'space-between',
-    align: 'center',
-    wrap: 'nowrap',
-    gap: '0',
-  }),
   {
     padding: '1rem',
-    boxSizing: 'border-box',
   },
 ]);

--- a/src/common/components/TopBar/index.tsx
+++ b/src/common/components/TopBar/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { TopBarPropsType } from './types';
 import { container } from './index.styles';
+import Flex from '../Flex';
 
 export default function TopBar({
   exitButton,
@@ -9,13 +10,18 @@ export default function TopBar({
   rightSlot,
 }: TopBarPropsType) {
   return (
-    <div css={container}>
+    <Flex
+      boxSizing="border-box"
+      justify="space-between"
+      width="100%"
+      css={container}
+    >
       <div>
         {!!exitButton && exitButton}
         {leftSlot}
       </div>
       <div>{centerSlot}</div>
       <div>{rightSlot}</div>
-    </div>
+    </Flex>
   );
 }

--- a/src/common/components/ViewportContainer/index.styles.ts
+++ b/src/common/components/ViewportContainer/index.styles.ts
@@ -1,0 +1,3 @@
+import { css } from '@emotion/react';
+
+export const viewportContainer = css({ minHeight: '100vh' });

--- a/src/common/components/ViewportContainer/index.tsx
+++ b/src/common/components/ViewportContainer/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { ViewportContainerPropsType } from './index.types';
+import Flex from '../Flex';
+import { viewportContainer } from './index.styles';
+
+export default function ViewportContainer({
+  children,
+  cx,
+}: ViewportContainerPropsType) {
+  return (
+    <Flex
+      direction="column"
+      width="100%"
+      boxSizing="border-box"
+      cx={[viewportContainer, cx]}
+      justify="start"
+      align="center"
+    >
+      {children}
+    </Flex>
+  );
+}

--- a/src/common/components/ViewportContainer/index.types.ts
+++ b/src/common/components/ViewportContainer/index.types.ts
@@ -1,0 +1,7 @@
+import { Interpolation, Theme } from '@emotion/react';
+import { ReactNode } from '@tanstack/react-router';
+
+export interface ViewportContainerPropsType {
+  children: ReactNode;
+  cx?: Interpolation<Theme>;
+}

--- a/src/stories/ActionBar.stories.tsx
+++ b/src/stories/ActionBar.stories.tsx
@@ -1,0 +1,170 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import ActionBar from '../common/components/ActionBar';
+import { css } from '@emotion/react';
+import theme from '../theme';
+import { Typography } from '../common/components';
+import Flex from '../common/components/Flex';
+import MainButton from '../common/components/MainButton';
+
+const meta = {
+  title: 'common/ActionBar',
+  component: ActionBar,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const PaymentAction: Story = {
+  args: {
+    bodySlot: (
+      <Flex
+        justify="space-between"
+        align="start"
+        cx={css({ width: '100%', boxSizing: 'border-box' })}
+      >
+        <Flex direction="column" justify="start" align="start">
+          <Typography
+            variant="title4"
+            cx={{
+              color: theme.colors.gray.black,
+            }}
+          >
+            총 결제금액
+          </Typography>
+          <Typography
+            variant="body3"
+            cx={{
+              color: theme.colors.gray[4],
+            }}
+          >
+            일반 1, 초등생 1
+          </Typography>
+        </Flex>
+        <Typography
+          variant="title1"
+          cx={{
+            color: theme.colors.gray.black,
+          }}
+        >
+          32,200원
+        </Typography>
+      </Flex>
+    ),
+    actionSlot: <MainButton>결제하기</MainButton>,
+  },
+};
+
+export const PaymentActionWithQuantity: Story = {
+  args: {
+    actionSlot: (
+      <MainButton>
+        <Flex gap="20px">
+          <span>30,200원 결제하기</span>
+          <Flex
+            cx={css({
+              borderRadius: theme.radii.circle,
+              width: '27px',
+              height: '27px',
+              backgroundColor: theme.colors.gray.white,
+              color: theme.colors.gray.black,
+            })}
+          >
+            <Typography variant="body3">3</Typography>
+          </Flex>
+        </Flex>
+      </MainButton>
+    ),
+  },
+};
+
+export const PaymentActionWithQuantityOnBottom: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: (Story) => (
+    <div css={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
+      <div css={{ flex: 1 }}>
+        <Typography variant="body3">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
+          dolor sit amet, consectetur adipiscing elit. Nullam non nisi est sit
+          amet facilisis magna etiam tempor. Sit amet luctus venenatis lectus
+          magna fringilla urna. Nunc congue nisi vitae suscipit tellus mauris.
+          Amet consectetur adipiscing elit pellentesque habitant morbi tristique
+          senectus et. Ultrices gravida dictum fusce ut placerat orci nulla
+          pellentesque dignissim. Velit dignissim sodales ut eu sem integer
+          vitae justo. Proin fermentum leo vel orci porta non. In hac habitasse
+          platea dictumst vestibulum rhoncus est pellentesque. Mi tempus
+          imperdiet nulla malesuada pellentesque elit eget gravida cum. Ultrices
+          mi tempus imperdiet nulla malesuada pellentesque elit eget gravida. At
+          imperdiet dui accumsan sit amet nulla facilisi morbi tempus. Tortor at
+          risus viverra adipiscing at in tellus integer feugiat. In eu mi
+          bibendum neque egestas congue quisque egestas diam. Auctor elit sed
+          vulputate mi sit amet mauris commodo quis imperdiet. Tellus
+          pellentesque eu tincidunt tortor aliquam nulla. Semper viverra nam
+          libero justo laoreet sit amet cursus sit. Orci ac auctor augue mauris
+          augue neque gravida. Tempor commodo ullamcorper a lacus vestibulum sed
+          arcu. Id neque aliquam vestibulum morbi blandit cursus risus at.
+          Mauris a diam maecenas sed enim ut sem viverra aliquet. Pretium fusce
+          id velit ut tortor pretium viverra. Donec ultrices tincidunt arcu non
+          sodales neque sodales ut etiam. Enim facilisis gravida neque convallis
+          a cras semper auctor. Massa tincidunt dui ut ornare lectus sit amet
+          est. Posuere ac ut consequat semper viverra nam libero justo laoreet.
+          Sed id semper risus in hendrerit gravida rutrum quisque. Pellentesque
+          elit eget gravida cum sociis natoque penatibus. Nibh praesent
+          tristique magna sit amet purus gravida quis blandit. Non pulvinar
+          neque laoreet suspendisse interdum consectetur libero id faucibus.Nisi
+          est sit amet facilisis magna etiam tempor orci. Ultricies lacus sed
+          turpis tincidunt id aliquet risus. Ut tortor pretium viverra
+          suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
+          quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
+          nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
+          sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
+          dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed
+          viverra tellus. Ipsum dolor sit amet consectetur adipiscing elit duis
+          tristique sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula
+          ullamcorper malesuada proin. Aliquam sem et tortor consequat id porta
+          nibh venenatis cras. Ultrices tincidunt arcu non sodales neque sodales
+          ut etiam. Malesuada bibendum arcu vitae elementum curabitur vitae
+          nunc. Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci
+          nulla pellentesque dignissim enim sit amet venenatis. Sed lectus
+          vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt.
+        </Typography>
+      </div>
+      <div
+        css={{
+          position: 'sticky',
+          bottom: 0,
+          width: '100%',
+        }}
+      >
+        <Story />
+      </div>
+    </div>
+  ),
+  args: {
+    actionSlot: (
+      <MainButton>
+        <Flex gap="20px">
+          <span>30,200원 결제하기</span>
+          <Flex
+            cx={css({
+              borderRadius: theme.radii.circle,
+              width: '27px',
+              height: '27px',
+              backgroundColor: theme.colors.gray.white,
+              color: theme.colors.gray.black,
+            })}
+          >
+            <Typography variant="body3">3</Typography>
+          </Flex>
+        </Flex>
+      </MainButton>
+    ),
+  },
+};

--- a/src/stories/ActionBar.stories.tsx
+++ b/src/stories/ActionBar.stories.tsx
@@ -82,60 +82,62 @@ export const PaymentActionWithQuantityOnBottom: Story = {
     layout: 'fullscreen',
   },
   decorators: (Story) => (
-    <div css={{ minHeight: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <div css={{ flex: 1 }}>
-        <Typography variant="body3">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
-          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
-          aliquip ex ea commodo consequat. Duis aute irure dolor in
-          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
-          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
-          culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
-          dolor sit amet, consectetur adipiscing elit. Nullam non nisi est sit
-          amet facilisis magna etiam tempor. Sit amet luctus venenatis lectus
-          magna fringilla urna. Nunc congue nisi vitae suscipit tellus mauris.
-          Amet consectetur adipiscing elit pellentesque habitant morbi tristique
-          senectus et. Ultrices gravida dictum fusce ut placerat orci nulla
-          pellentesque dignissim. Velit dignissim sodales ut eu sem integer
-          vitae justo. Proin fermentum leo vel orci porta non. In hac habitasse
-          platea dictumst vestibulum rhoncus est pellentesque. Mi tempus
-          imperdiet nulla malesuada pellentesque elit eget gravida cum. Ultrices
-          mi tempus imperdiet nulla malesuada pellentesque elit eget gravida. At
-          imperdiet dui accumsan sit amet nulla facilisi morbi tempus. Tortor at
-          risus viverra adipiscing at in tellus integer feugiat. In eu mi
-          bibendum neque egestas congue quisque egestas diam. Auctor elit sed
-          vulputate mi sit amet mauris commodo quis imperdiet. Tellus
-          pellentesque eu tincidunt tortor aliquam nulla. Semper viverra nam
-          libero justo laoreet sit amet cursus sit. Orci ac auctor augue mauris
-          augue neque gravida. Tempor commodo ullamcorper a lacus vestibulum sed
-          arcu. Id neque aliquam vestibulum morbi blandit cursus risus at.
-          Mauris a diam maecenas sed enim ut sem viverra aliquet. Pretium fusce
-          id velit ut tortor pretium viverra. Donec ultrices tincidunt arcu non
-          sodales neque sodales ut etiam. Enim facilisis gravida neque convallis
-          a cras semper auctor. Massa tincidunt dui ut ornare lectus sit amet
-          est. Posuere ac ut consequat semper viverra nam libero justo laoreet.
-          Sed id semper risus in hendrerit gravida rutrum quisque. Pellentesque
-          elit eget gravida cum sociis natoque penatibus. Nibh praesent
-          tristique magna sit amet purus gravida quis blandit. Non pulvinar
-          neque laoreet suspendisse interdum consectetur libero id faucibus.Nisi
-          est sit amet facilisis magna etiam tempor orci. Ultricies lacus sed
-          turpis tincidunt id aliquet risus. Ut tortor pretium viverra
-          suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
-          quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
-          nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
-          sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
-          dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed
-          viverra tellus. Ipsum dolor sit amet consectetur adipiscing elit duis
-          tristique sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula
-          ullamcorper malesuada proin. Aliquam sem et tortor consequat id porta
-          nibh venenatis cras. Ultrices tincidunt arcu non sodales neque sodales
-          ut etiam. Malesuada bibendum arcu vitae elementum curabitur vitae
-          nunc. Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci
-          nulla pellentesque dignissim enim sit amet venenatis. Sed lectus
-          vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt.
-        </Typography>
-      </div>
+    <Flex
+      direction="column"
+      justify="start"
+      align="center"
+      css={{ minHeight: '100vh' }}
+    >
+      <Typography variant="body3" cx={{ flex: 1 }}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Nullam non nisi est sit amet facilisis magna etiam
+        tempor. Sit amet luctus venenatis lectus magna fringilla urna. Nunc
+        congue nisi vitae suscipit tellus mauris. Amet consectetur adipiscing
+        elit pellentesque habitant morbi tristique senectus et. Ultrices gravida
+        dictum fusce ut placerat orci nulla pellentesque dignissim. Velit
+        dignissim sodales ut eu sem integer vitae justo. Proin fermentum leo vel
+        orci porta non. In hac habitasse platea dictumst vestibulum rhoncus est
+        pellentesque. Mi tempus imperdiet nulla malesuada pellentesque elit eget
+        gravida cum. Ultrices mi tempus imperdiet nulla malesuada pellentesque
+        elit eget gravida. At imperdiet dui accumsan sit amet nulla facilisi
+        morbi tempus. Tortor at risus viverra adipiscing at in tellus integer
+        feugiat. In eu mi bibendum neque egestas congue quisque egestas diam.
+        Auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet.
+        Tellus pellentesque eu tincidunt tortor aliquam nulla. Semper viverra
+        nam libero justo laoreet sit amet cursus sit. Orci ac auctor augue
+        mauris augue neque gravida. Tempor commodo ullamcorper a lacus
+        vestibulum sed arcu. Id neque aliquam vestibulum morbi blandit cursus
+        risus at. Mauris a diam maecenas sed enim ut sem viverra aliquet.
+        Pretium fusce id velit ut tortor pretium viverra. Donec ultrices
+        tincidunt arcu non sodales neque sodales ut etiam. Enim facilisis
+        gravida neque convallis a cras semper auctor. Massa tincidunt dui ut
+        ornare lectus sit amet est. Posuere ac ut consequat semper viverra nam
+        libero justo laoreet. Sed id semper risus in hendrerit gravida rutrum
+        quisque. Pellentesque elit eget gravida cum sociis natoque penatibus.
+        Nibh praesent tristique magna sit amet purus gravida quis blandit. Non
+        pulvinar neque laoreet suspendisse interdum consectetur libero id
+        faucibus.Nisi est sit amet facilisis magna etiam tempor orci. Ultricies
+        lacus sed turpis tincidunt id aliquet risus. Ut tortor pretium viverra
+        suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
+        quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
+        nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
+        sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
+        dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed viverra
+        tellus. Ipsum dolor sit amet consectetur adipiscing elit duis tristique
+        sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula ullamcorper
+        malesuada proin. Aliquam sem et tortor consequat id porta nibh venenatis
+        cras. Ultrices tincidunt arcu non sodales neque sodales ut etiam.
+        Malesuada bibendum arcu vitae elementum curabitur vitae nunc.
+        Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci nulla
+        pellentesque dignissim enim sit amet venenatis. Sed lectus vestibulum
+        mattis ullamcorper velit sed ullamcorper morbi tincidunt.
+      </Typography>
       <div
         css={{
           position: 'sticky',
@@ -145,7 +147,7 @@ export const PaymentActionWithQuantityOnBottom: Story = {
       >
         <Story />
       </div>
-    </div>
+    </Flex>
   ),
   args: {
     actionSlot: (

--- a/src/stories/ActionBar.stories.tsx
+++ b/src/stories/ActionBar.stories.tsx
@@ -5,6 +5,7 @@ import theme from '../theme';
 import { Typography } from '../common/components';
 import Flex from '../common/components/Flex';
 import MainButton from '../common/components/MainButton';
+import StickyFooter from '../common/components/StickyFooter';
 
 const meta = {
   title: 'common/ActionBar',
@@ -138,15 +139,9 @@ export const PaymentActionWithQuantityOnBottom: Story = {
         pellentesque dignissim enim sit amet venenatis. Sed lectus vestibulum
         mattis ullamcorper velit sed ullamcorper morbi tincidunt.
       </Typography>
-      <div
-        css={{
-          position: 'sticky',
-          bottom: 0,
-          width: '100%',
-        }}
-      >
+      <StickyFooter>
         <Story />
-      </div>
+      </StickyFooter>
     </Flex>
   ),
   args: {

--- a/src/stories/StickyFooter.stories.tsx
+++ b/src/stories/StickyFooter.stories.tsx
@@ -6,6 +6,7 @@ import Flex from '../common/components/Flex';
 import { css } from '@emotion/react';
 import theme from '../theme';
 import { Typography } from '../common/components';
+import ViewportContainer from '../common/components/ViewportContainer';
 
 const meta = {
   title: 'common/StickyFooter',
@@ -20,14 +21,7 @@ export const Default: Story = {
     layout: 'fullscreen',
   },
   decorators: (Story) => (
-    <Flex
-      direction="column"
-      width="100%"
-      boxSizing="border-box"
-      cx={{ minHeight: '100vh' }}
-      justify="start"
-      align="center"
-    >
+    <ViewportContainer>
       <Typography variant="body3">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -79,7 +73,7 @@ export const Default: Story = {
         mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
       </Typography>
       <Story />
-    </Flex>
+    </ViewportContainer>
   ),
   args: {
     children: (

--- a/src/stories/StickyFooter.stories.tsx
+++ b/src/stories/StickyFooter.stories.tsx
@@ -76,6 +76,7 @@ export const Default: Story = {
     </ViewportContainer>
   ),
   args: {
+    as: 'section',
     children: (
       <ActionBar
         actionSlot={

--- a/src/stories/StickyFooter.stories.tsx
+++ b/src/stories/StickyFooter.stories.tsx
@@ -1,0 +1,108 @@
+import { Meta, StoryObj } from '@storybook/react';
+import StickyFooter from '../common/components/StickyFooter';
+import ActionBar from '../common/components/ActionBar';
+import MainButton from '../common/components/MainButton';
+import Flex from '../common/components/Flex';
+import { css } from '@emotion/react';
+import theme from '../theme';
+import { Typography } from '../common/components';
+
+const meta = {
+  title: 'common/StickyFooter',
+  component: StickyFooter,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: (Story) => (
+    <Flex
+      direction="column"
+      width="100%"
+      boxSizing="border-box"
+      cx={{ minHeight: '100vh' }}
+      justify="start"
+      align="center"
+    >
+      <Typography variant="body3">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Nullam non nisi est sit amet facilisis magna etiam
+        tempor. Sit amet luctus venenatis lectus magna fringilla urna. Nunc
+        congue nisi vitae suscipit tellus mauris. Amet consectetur adipiscing
+        elit pellentesque habitant morbi tristique senectus et. Ultrices gravida
+        dictum fusce ut placerat orci nulla pellentesque dignissim. Velit
+        dignissim sodales ut eu sem integer vitae justo. Proin fermentum leo vel
+        orci porta non. In hac habitasse platea dictumst vestibulum rhoncus est
+        pellentesque. Mi tempus imperdiet nulla malesuada pellentesque elit eget
+        gravida cum. Ultrices mi tempus imperdiet nulla malesuada pellentesque
+        elit eget gravida. At imperdiet dui accumsan sit amet nulla facilisi
+        morbi tempus. Tortor at risus viverra adipiscing at in tellus integer
+        feugiat. In eu mi bibendum neque egestas congue quisque egestas diam.
+        Auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet.
+        Tellus pellentesque eu tincidunt tortor aliquam nulla. Semper viverra
+        nam libero justo laoreet sit amet cursus sit. Orci ac auctor augue
+        mauris augue neque gravida. Tempor commodo ullamcorper a lacus
+        vestibulum sed arcu. Id neque aliquam vestibulum morbi blandit cursus
+        risus at. Mauris a diam maecenas sed enim ut sem viverra aliquet.
+        Pretium fusce id velit ut tortor pretium viverra. Donec ultrices
+        tincidunt arcu non sodales neque sodales ut etiam. Enim facilisis
+        gravida neque convallis a cras semper auctor. Massa tincidunt dui ut
+        ornare lectus sit amet est. Posuere ac ut consequat semper viverra nam
+        libero justo laoreet. Sed id semper risus in hendrerit gravida rutrum
+        quisque. Pellentesque elit eget gravida cum sociis natoque penatibus.
+        Nibh praesent tristique magna sit amet purus gravida quis blandit. Non
+        pulvinar neque laoreet suspendisse interdum consectetur libero id
+        faucibus.Nisi est sit amet facilisis magna etiam tempor orci. Ultricies
+        lacus sed turpis tincidunt id aliquet risus. Ut tortor pretium viverra
+        suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
+        quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
+        nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
+        sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
+        dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed viverra
+        tellus. Ipsum dolor sit amet consectetur adipiscing elit duis tristique
+        sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula ullamcorper
+        malesuada proin. Aliquam sem et tortor consequat id porta nibh venenatis
+        cras. Ultrices tincidunt arcu non sodales neque sodales ut etiam.
+        Malesuada bibendum arcu vitae elementum curabitur vitae nunc.
+        Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci nulla
+        pellentesque dignissim enim sit amet venenatis. Sed lectus vestibulum
+        mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
+      </Typography>
+      <Story />
+    </Flex>
+  ),
+  args: {
+    children: (
+      <ActionBar
+        actionSlot={
+          <MainButton>
+            <Flex gap="20px">
+              <span>30,200원 결제하기</span>
+              <Flex
+                cx={css({
+                  borderRadius: theme.radii.circle,
+                  width: '27px',
+                  height: '27px',
+                  backgroundColor: theme.colors.gray.white,
+                  color: theme.colors.gray.black,
+                })}
+              >
+                <Typography variant="body3">3</Typography>
+              </Flex>
+            </Flex>
+          </MainButton>
+        }
+      />
+    ),
+  },
+};

--- a/src/stories/StickyHeader.stories.tsx
+++ b/src/stories/StickyHeader.stories.tsx
@@ -1,0 +1,105 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { Button, TopBar, Typography } from '../common/components';
+import Flex from '../common/components/Flex';
+import StikcyHeader from '../common/components/StickyHeader';
+import LeftArrowIcon from '../assets/LeftArrowIcon.svg?react';
+import theme from '../theme';
+
+const meta = {
+  title: 'common/StikcyHeader',
+  component: StikcyHeader,
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: (Story) => (
+    <Flex
+      direction="column"
+      width="100%"
+      boxSizing="border-box"
+      cx={{ minHeight: '100vh' }}
+      justify="start"
+      align="center"
+    >
+      <Story />
+      <Typography variant="body3">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+        velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint
+        occaecat cupidatat non proident, sunt in culpa qui officia deserunt
+        mollit anim id est laborum. Lorem ipsum dolor sit amet, consectetur
+        adipiscing elit. Nullam non nisi est sit amet facilisis magna etiam
+        tempor. Sit amet luctus venenatis lectus magna fringilla urna. Nunc
+        congue nisi vitae suscipit tellus mauris. Amet consectetur adipiscing
+        elit pellentesque habitant morbi tristique senectus et. Ultrices gravida
+        dictum fusce ut placerat orci nulla pellentesque dignissim. Velit
+        dignissim sodales ut eu sem integer vitae justo. Proin fermentum leo vel
+        orci porta non. In hac habitasse platea dictumst vestibulum rhoncus est
+        pellentesque. Mi tempus imperdiet nulla malesuada pellentesque elit eget
+        gravida cum. Ultrices mi tempus imperdiet nulla malesuada pellentesque
+        elit eget gravida. At imperdiet dui accumsan sit amet nulla facilisi
+        morbi tempus. Tortor at risus viverra adipiscing at in tellus integer
+        feugiat. In eu mi bibendum neque egestas congue quisque egestas diam.
+        Auctor elit sed vulputate mi sit amet mauris commodo quis imperdiet.
+        Tellus pellentesque eu tincidunt tortor aliquam nulla. Semper viverra
+        nam libero justo laoreet sit amet cursus sit. Orci ac auctor augue
+        mauris augue neque gravida. Tempor commodo ullamcorper a lacus
+        vestibulum sed arcu. Id neque aliquam vestibulum morbi blandit cursus
+        risus at. Mauris a diam maecenas sed enim ut sem viverra aliquet.
+        Pretium fusce id velit ut tortor pretium viverra. Donec ultrices
+        tincidunt arcu non sodales neque sodales ut etiam. Enim facilisis
+        gravida neque convallis a cras semper auctor. Massa tincidunt dui ut
+        ornare lectus sit amet est. Posuere ac ut consequat semper viverra nam
+        libero justo laoreet. Sed id semper risus in hendrerit gravida rutrum
+        quisque. Pellentesque elit eget gravida cum sociis natoque penatibus.
+        Nibh praesent tristique magna sit amet purus gravida quis blandit. Non
+        pulvinar neque laoreet suspendisse interdum consectetur libero id
+        faucibus.Nisi est sit amet facilisis magna etiam tempor orci. Ultricies
+        lacus sed turpis tincidunt id aliquet risus. Ut tortor pretium viverra
+        suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
+        quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
+        nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
+        sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
+        dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed viverra
+        tellus. Ipsum dolor sit amet consectetur adipiscing elit duis tristique
+        sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula ullamcorper
+        malesuada proin. Aliquam sem et tortor consequat id porta nibh venenatis
+        cras. Ultrices tincidunt arcu non sodales neque sodales ut etiam.
+        Malesuada bibendum arcu vitae elementum curabitur vitae nunc.
+        Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci nulla
+        pellentesque dignissim enim sit amet venenatis. Sed lectus vestibulum
+        mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
+      </Typography>
+    </Flex>
+  ),
+  args: {
+    children: (
+      <TopBar
+        leftSlot={
+          <Button>
+            <LeftArrowIcon />
+          </Button>
+        }
+        centerSlot={
+          <Typography variant="body2" cx={{ fontSize: '1.125rem' }}>
+            결제하기
+          </Typography>
+        }
+        rightSlot={
+          <Button cx={{ color: theme.colors.primary.base }}>
+            <Typography variant="title4">결제수단</Typography>
+          </Button>
+        }
+      />
+    ),
+  },
+};

--- a/src/stories/StickyHeader.stories.tsx
+++ b/src/stories/StickyHeader.stories.tsx
@@ -5,6 +5,7 @@ import Flex from '../common/components/Flex';
 import StikcyHeader from '../common/components/StickyHeader';
 import LeftArrowIcon from '../assets/LeftArrowIcon.svg?react';
 import theme from '../theme';
+import ViewportContainer from '../common/components/ViewportContainer';
 
 const meta = {
   title: 'common/StikcyHeader',
@@ -20,14 +21,7 @@ export const Default: Story = {
     layout: 'fullscreen',
   },
   decorators: (Story) => (
-    <Flex
-      direction="column"
-      width="100%"
-      boxSizing="border-box"
-      cx={{ minHeight: '100vh' }}
-      justify="start"
-      align="center"
-    >
+    <ViewportContainer>
       <Story />
       <Typography variant="body3">
         Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
@@ -79,7 +73,7 @@ export const Default: Story = {
         pellentesque dignissim enim sit amet venenatis. Sed lectus vestibulum
         mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
       </Typography>
-    </Flex>
+    </ViewportContainer>
   ),
   args: {
     children: (

--- a/src/stories/TopBar.stories.tsx
+++ b/src/stories/TopBar.stories.tsx
@@ -1,12 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import TopBar from '../common/components/TopBar';
 import LogoIcon from '../assets/LogoIcon.svg?react';
-import { css } from '@emotion/react';
 import Button from '../common/components/Button';
 import LanguageSwitchButton from '../common/components/LanguageSwitchButton';
 import LeftArrowIcon from '../assets/LeftArrowIcon.svg?react';
-import { buildTypography } from '../common/components/Typography/index.styles';
 import theme from '../theme';
+import Typography from '../common/components/Typography';
 
 const meta = {
   title: 'common/TopBar',
@@ -45,22 +44,13 @@ export const Payment: Story = {
       </Button>
     ),
     centerSlot: (
-      <div
-        css={css([buildTypography(theme, 'body2'), { fontSize: '1.125rem' }])}
-      >
+      <Typography variant="body2" cx={{ fontSize: '1.125rem' }}>
         결제하기
-      </div>
+      </Typography>
     ),
     rightSlot: (
-      <Button
-        css={css([
-          buildTypography(theme, 'title4'),
-          {
-            color: theme.colors.primary.base,
-          },
-        ])}
-      >
-        결제수단
+      <Button cx={{ color: theme.colors.primary.base }}>
+        <Typography variant="title4">결제수단</Typography>
       </Button>
     ),
   },

--- a/src/stories/ViewportContainer.stories.tsx
+++ b/src/stories/ViewportContainer.stories.tsx
@@ -95,7 +95,7 @@ export const Default: Story = {
           nulla pellentesque dignissim enim sit amet venenatis. Sed lectus
           vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
         </Typography>
-        <StickyFooter>
+        <StickyFooter as="section">
           <ActionBar
             actionSlot={
               <MainButton>

--- a/src/stories/ViewportContainer.stories.tsx
+++ b/src/stories/ViewportContainer.stories.tsx
@@ -1,0 +1,123 @@
+import { Meta, StoryObj } from '@storybook/react';
+import ViewportContainer from '../common/components/ViewportContainer';
+import { Button, TopBar, Typography } from '../common/components';
+import StikcyHeader from '../common/components/StickyHeader';
+import theme from '../theme';
+import LeftArrowIcon from '../assets/LeftArrowIcon.svg?react';
+import MainButton from '../common/components/MainButton';
+import Flex from '../common/components/Flex';
+import { css } from '@emotion/react';
+import ActionBar from '../common/components/ActionBar';
+import StickyFooter from '../common/components/StickyFooter';
+
+const meta = {
+  title: 'common/ViewportContainer',
+  component: ViewportContainer,
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    layout: 'fullscreen',
+  },
+  args: {
+    children: (
+      <>
+        <StikcyHeader>
+          <TopBar
+            leftSlot={
+              <Button>
+                <LeftArrowIcon />
+              </Button>
+            }
+            centerSlot={
+              <Typography variant="body2" cx={{ fontSize: '1.125rem' }}>
+                결제하기
+              </Typography>
+            }
+            rightSlot={
+              <Button cx={{ color: theme.colors.primary.base }}>
+                <Typography variant="title4">결제수단</Typography>
+              </Button>
+            }
+          />
+        </StikcyHeader>
+        <Typography variant="body3">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum. Lorem ipsum
+          dolor sit amet, consectetur adipiscing elit. Nullam non nisi est sit
+          amet facilisis magna etiam tempor. Sit amet luctus venenatis lectus
+          magna fringilla urna. Nunc congue nisi vitae suscipit tellus mauris.
+          Amet consectetur adipiscing elit pellentesque habitant morbi tristique
+          senectus et. Ultrices gravida dictum fusce ut placerat orci nulla
+          pellentesque dignissim. Velit dignissim sodales ut eu sem integer
+          vitae justo. Proin fermentum leo vel orci porta non. In hac habitasse
+          platea dictumst vestibulum rhoncus est pellentesque. Mi tempus
+          imperdiet nulla malesuada pellentesque elit eget gravida cum. Ultrices
+          mi tempus imperdiet nulla malesuada pellentesque elit eget gravida. At
+          imperdiet dui accumsan sit amet nulla facilisi morbi tempus. Tortor at
+          risus viverra adipiscing at in tellus integer feugiat. In eu mi
+          bibendum neque egestas congue quisque egestas diam. Auctor elit sed
+          vulputate mi sit amet mauris commodo quis imperdiet. Tellus
+          pellentesque eu tincidunt tortor aliquam nulla. Semper viverra nam
+          libero justo laoreet sit amet cursus sit. Orci ac auctor augue mauris
+          augue neque gravida. Tempor commodo ullamcorper a lacus vestibulum sed
+          arcu. Id neque aliquam vestibulum morbi blandit cursus risus at.
+          Mauris a diam maecenas sed enim ut sem viverra aliquet. Pretium fusce
+          id velit ut tortor pretium viverra. Donec ultrices tincidunt arcu non
+          sodales neque sodales ut etiam. Enim facilisis gravida neque convallis
+          a cras semper auctor. Massa tincidunt dui ut ornare lectus sit amet
+          est. Posuere ac ut consequat semper viverra nam libero justo laoreet.
+          Sed id semper risus in hendrerit gravida rutrum quisque. Pellentesque
+          elit eget gravida cum sociis natoque penatibus. Nibh praesent
+          tristique magna sit amet purus gravida quis blandit. Non pulvinar
+          neque laoreet suspendisse interdum consectetur libero id faucibus.Nisi
+          est sit amet facilisis magna etiam tempor orci. Ultricies lacus sed
+          turpis tincidunt id aliquet risus. Ut tortor pretium viverra
+          suspendisse potenti nullam ac tortor. Eget dolor morbi non arcu risus
+          quis varius quam. Tellus integer feugiat scelerisque varius morbi enim
+          nunc faucibus a. Enim nec dui nunc mattis enim ut tellus elementum
+          sagittis. Volutpat lacus laoreet non curabitur gravida arcu ac tortor
+          dignissim. Purus faucibus ornare suspendisse sed nisi lacus sed
+          viverra tellus. Ipsum dolor sit amet consectetur adipiscing elit duis
+          tristique sollicitudin. Massa tincidunt nunc pulvinar sapien et ligula
+          ullamcorper malesuada proin. Aliquam sem et tortor consequat id porta
+          nibh venenatis cras. Ultrices tincidunt arcu non sodales neque sodales
+          ut etiam. Malesuada bibendum arcu vitae elementum curabitur vitae
+          nunc. Suspendisse sed nisi lacus sed viverra tellus. Ut placerat orci
+          nulla pellentesque dignissim enim sit amet venenatis. Sed lectus
+          vestibulum mattis ullamcorper velit sed ullamcorper morbi tincidunt.s
+        </Typography>
+        <StickyFooter>
+          <ActionBar
+            actionSlot={
+              <MainButton>
+                <Flex gap="20px">
+                  <span>30,200원 결제하기</span>
+                  <Flex
+                    cx={css({
+                      borderRadius: theme.radii.circle,
+                      width: '27px',
+                      height: '27px',
+                      backgroundColor: theme.colors.gray.white,
+                      color: theme.colors.gray.black,
+                    })}
+                  >
+                    <Typography variant="body3">3</Typography>
+                  </Flex>
+                </Flex>
+              </MainButton>
+            }
+          />
+        </StickyFooter>
+      </>
+    ),
+  },
+};


### PR DESCRIPTION
## Summary

- StickyFooter, StickyHeader를 통해서 재사용 가능한 Sticky Layout을 만들었습니다. 탑바, 바텀시트, 바텀바 등을 담을 수 있습니다.

## Description

- 자세한 사용법은 `ViewportContainer`, `StickyFooter.stories.tsx`, `StickyHeader.stories.tsx`를 참고해주세요.

1. ViweportContainer로 viewport 사이즈까지 범위 확장
2. StickyFooter, StickyHeader가 각자 자리 잡음
3. 나머지 여백을 Content로 채운다.
