### PR TITLE
refactor/make destDate prop optional

### DIFF
--- a/src/stores/useSearchQueryStore/index.ts
+++ b/src/stores/useSearchQueryStore/index.ts
@@ -6,7 +6,7 @@ const initialState = {
     startId: '',
     destId: '',
     startDate: new Date(),
-    destDate: new Date(),
+    destDate: null,
   },
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ export interface SearchQuery {
   startId: string;
   destId: string;
   startDate: Date;
-  destDate: Date;
+  destDate?: Date | null;
 }
 
 interface Fee {


### PR DESCRIPTION
## Summary

searchQuery에서 destDate의 type이 undefined 및 null이 될 수 있도록 union type으로 수정하였습니다.

## Description

**영향 받는 파일은 다음과 같아요.**
- `useSearchQueryStore`

SearchQuery type과 별개로, 티켓 조회 버튼을 눌렀을 때 발생하는 validation logic은 destDate가 falsy value인지 검증해야할 것 같습니다.




