### PR TITLE
feat/persist-purchased-ticket-list

### DIFF
--- a/src/stores/useReservationStore/index.ts
+++ b/src/stores/useReservationStore/index.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { ReservationState } from './index.types';
+import { persist } from 'zustand/middleware';
 
 const initialState = {
   selectedOutboundBus: null,
@@ -12,61 +13,71 @@ const initialState = {
   selectedInboundSeat: [],
 };
 
-const useReservationStore = create<ReservationState>()((set) => ({
-  ...initialState,
-  selectOutboundBus: (bus) =>
-    set((state) => ({ ...state, selectedOutboundBus: bus })),
-  selectInboundBus: (bus) =>
-    set((state) => ({ ...state, selectedInboundBus: bus })),
-  selectOutboundSeatList: (seatList) =>
-    set((state) => ({ ...state, selectedOutboundSeatList: seatList })),
-  selectInboundSeatList: (seatList) =>
-    set((state) => ({ ...state, selectedInboundSeatList: seatList })),
-  issueTicketList: () =>
-    set((state) => {
-      if (state.selectedOutboundBus && state.selectedInboundBus) {
-        const outboundTicket = {
-          ...state.selectedOutboundBus,
-          seats: [...state.selectedOutboundSeatList],
-        };
-        const inboundTicket = {
-          ...state.selectedInboundBus,
-          seats: [...state.selectedInboundSeatList],
-        };
+const useReservationStore = create<ReservationState>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      selectOutboundBus: (bus) =>
+        set((state) => ({ ...state, selectedOutboundBus: bus })),
+      selectInboundBus: (bus) =>
+        set((state) => ({ ...state, selectedInboundBus: bus })),
+      selectOutboundSeatList: (seatList) =>
+        set((state) => ({ ...state, selectedOutboundSeatList: seatList })),
+      selectInboundSeatList: (seatList) =>
+        set((state) => ({ ...state, selectedInboundSeatList: seatList })),
+      issueTicketList: () =>
+        set((state) => {
+          if (state.selectedOutboundBus && state.selectedInboundBus) {
+            const outboundTicket = {
+              ...state.selectedOutboundBus,
+              seats: [...state.selectedOutboundSeatList],
+            };
+            const inboundTicket = {
+              ...state.selectedInboundBus,
+              seats: [...state.selectedInboundSeatList],
+            };
 
-        return {
+            return {
+              ...state,
+              pendingTicketList: [
+                ...state.pendingTicketList,
+                outboundTicket,
+                inboundTicket,
+              ],
+            };
+          }
+          if (state.selectedOutboundBus) {
+            const outboundTicket = {
+              ...state.selectedOutboundBus,
+              seats: [...state.selectedOutboundBus.seats],
+            };
+
+            return {
+              ...state,
+              pendingTicketList: [...state.pendingTicketList, outboundTicket],
+            };
+          }
+
+          return {
+            ...state,
+          };
+        }),
+      purchaseTicketList: () =>
+        set((state) => ({
           ...state,
-          pendingTicketList: [
+          purchasedTicketList: [
+            ...state.purchasedTicketList,
             ...state.pendingTicketList,
-            outboundTicket,
-            inboundTicket,
           ],
-        };
-      }
-      if (state.selectedOutboundBus) {
-        const outboundTicket = {
-          ...state.selectedOutboundBus,
-          seats: [...state.selectedOutboundBus.seats],
-        };
-
-        return {
-          ...state,
-          pendingTicketList: [...state.pendingTicketList, outboundTicket],
-        };
-      }
-
-      return {
-        ...state,
-      };
+        })),
     }),
-  purchaseTicketList: () =>
-    set((state) => ({
-      ...state,
-      purchasedTicketList: [
-        ...state.purchasedTicketList,
-        ...state.pendingTicketList,
-      ],
-    })),
-}));
+    {
+      name: 'reservationStore',
+      partialize: (state) => ({
+        purchasedTicketList: state.purchasedTicketList,
+      }),
+    }
+  )
+);
 
 export default useReservationStore;


### PR DESCRIPTION
## Summary

결제된 티켓 목록이 localStorage에 저장될 수 있게 하였습니다.

## Description

- 시연 때 결제된 티켓 목록을 저장하여 현실감 있게 하기 위해서, local storage에 purchasedTicketList 프로퍼티만 reservationStore에서 선택적으로 저장할 수 있게 하였습니다.
- store 로드시 자동으로 localStorage에 존재하는 purachesTicketList 데이터가 로드됩니다.
